### PR TITLE
Show only incorrect guesses in wrong letters list (fixes #4)

### DIFF
--- a/script.js
+++ b/script.js
@@ -220,17 +220,19 @@ function updateWordDisplay() {
 }
 
 function updateWrongLetters() {
+    //after the fix 
     const wrongLettersDiv = document.getElementById('wrongLetters');
-    const wrong = gameState.guessedLetters.filter(letter => 
+    const wrong = gameState.guessedLetters.filter(letter =>
         !gameState.currentWord.includes(letter)
     );
-    
+
     if (wrong.length === 0) {
         wrongLettersDiv.textContent = 'None yet';
     } else {
-        wrongLettersDiv.textContent = gameState.guessedLetters.join(', ');
+        wrongLettersDiv.textContent = wrong.join(', ');
     }
 }
+
 
 function updateLives() {
     const livesLeft = gameState.maxWrong - gameState.wrongGuesses + 1;


### PR DESCRIPTION
fixed the issue by editing updateWrongLetters function now it does this:
1. if a letter is correct will not add it to wrong letters 
2. if a letter is wronge will add it to to wrong letters 
no letter from the word is in the wronge letter box :
<img width="1841" height="739" alt="image" src="https://github.com/user-attachments/assets/32429caf-0bba-444a-a3a0-ca199700b7b7" />
