### PR TITLE
Fix lives calculation to match maxWrong and reach 0 on loss (fixes #6)

### DIFF
--- a/script.js
+++ b/script.js
@@ -235,9 +235,11 @@ function updateWrongLetters() {
 
 
 function updateLives() {
-    const livesLeft = gameState.maxWrong - gameState.wrongGuesses + 1;
-    document.getElementById('livesLeft').textContent = livesLeft;
+    //after edit 
+    const livesLeft = gameState.maxWrong - gameState.wrongGuesses;
+    document.getElementById('livesLeft').textContent = Math.max(0, livesLeft);
 }
+
 
 function updateHangman() {
     const parts = ['head', 'body', 'leftArm', 'rightArm', 'leftLeg', 'rightLeg'];


### PR DESCRIPTION
changed the code for updateLives function to reach 0 on loose 

<img width="879" height="827" alt="image" src="https://github.com/user-attachments/assets/60b6b7ab-d6bd-49e8-be9e-6824cf837e0f" />
