### PR TITLE
Implement dark/light theme toggle with persistence (fixes #8)

### DIFF
--- a/script.js
+++ b/script.js
@@ -19,20 +19,44 @@ let gameState = {
 
 let wordBank = [];
 
+//edit it for #8 (add applySavedTheme)
 document.addEventListener('DOMContentLoaded', function() {
+    applySavedTheme();
     loadWordBank();
     generateKeyboard();
 });
 
+
+
 function toggleTheme() {
+    const body = document.body;
     const themeIcon = document.querySelector('.theme-icon');
-    
-    if (themeIcon.textContent === '🌙') {
+
+    const isDark = body.classList.toggle('dark-mode');
+
+    // Persist
+    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+
+    // Icon rule: 🌙 for light mode, ☀️ for dark mode
+    themeIcon.textContent = isDark ? '☀️' : '🌙';
+}
+
+//new function to fix issue #8 
+
+function applySavedTheme() {
+    const saved = localStorage.getItem('theme') || 'light';
+    const body = document.body;
+    const themeIcon = document.querySelector('.theme-icon');
+
+    if (saved === 'dark') {
+        body.classList.add('dark-mode');
         themeIcon.textContent = '☀️';
     } else {
+        body.classList.remove('dark-mode');
         themeIcon.textContent = '🌙';
     }
 }
+
 
 function switchTab(tabName) {
     const tabs = document.querySelectorAll('.tab-content');


### PR DESCRIPTION
now the issue #8  is fixed the moon will implement dark view while the sun will implement bright view and this will not change even after refresh. (when u press the sun u git the bright view and the button will display a moon now and the oposit is also correct)


<img width="1191" height="886" alt="image" src="https://github.com/user-attachments/assets/9199b3fc-9f0e-4572-a58e-824766b33385" />

<img width="977" height="875" alt="image" src="https://github.com/user-attachments/assets/ec63677b-1dec-49b5-83a3-cdecd058d4b9" />

updatethe toggleTheme function/ add applySavedTheme function / Update the existing DOMContentLoaded block
